### PR TITLE
refactor the arguments parsing of sefs-cli

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -62,3 +62,5 @@ jobs:
       uses: actions-rs/cargo@v1
       with:
         command: doc
+      env:
+        RUSTDOCFLAGS: '-Dwarnings -Aunused_braces'

--- a/sefs-cli/app/src/sgx_dev.rs
+++ b/sefs-cli/app/src/sgx_dev.rs
@@ -89,7 +89,7 @@ impl File for SgxFile {
     fn flush(&self) -> DevResult<()> {
         match file_flush(self.file) {
             0 => Ok(()),
-            e => {
+            _ => {
                 println!("failed to flush");
                 return Err(DeviceError);
             }


### PR DESCRIPTION
The original implementation of `sefc-cli` is not the best practice of `StructOpt`, so it cannot handle that if one argument is the same with one subcommand.