### PR TITLE
remove the drop guard of Dirty

### DIFF
--- a/rcore-fs/src/dirty.rs
+++ b/rcore-fs/src/dirty.rs
@@ -54,13 +54,6 @@ impl<T> DerefMut for Dirty<T> {
     }
 }
 
-impl<T> Drop for Dirty<T> {
-    /// Guard it is not dirty when dropping
-    fn drop(&mut self) {
-        assert!(!self.dirty, "data dirty when dropping");
-    }
-}
-
 impl<T: Debug> Debug for Dirty<T> {
     fn fmt(&self, f: &mut Formatter) -> Result<(), Error> {
         let tag = if self.dirty { "Dirty" } else { "Clean" };


### PR DESCRIPTION
If a struct is constructed with `Dirty::new_dirty`, any following
returned errors will cause an assertion failure when dropping it,
because the struct is dirty, it is too complicated to clear the dirty
state in every subsequent error handler.

After this commit, users **MUST** ensure that the useful dirty struct is
correctly flushed before dropping it. If the dirty struct becomes useless
because of errors, users can just drop it.