### PR TITLE
BUG: incompatible timespec convertion from rust to c

### DIFF
--- a/rcore-fs-cli/src/fuse.rs
+++ b/rcore-fs-cli/src/fuse.rs
@@ -24,13 +24,13 @@ impl VfsFuse {
     fn trans_time(time: vfs::Timespec) -> Timespec {
         Timespec {
             sec: time.sec,
-            nsec: time.nsec,
+            nsec: time.nsec as i32,
         }
     }
     fn trans_time_r(time: Timespec) -> vfs::Timespec {
         vfs::Timespec {
             sec: time.sec,
-            nsec: time.nsec,
+            nsec: time.nsec as i64,
         }
     }
     fn trans_attr(info: vfs::Metadata) -> FileAttr {

--- a/rcore-fs-sefs/src/lib.rs
+++ b/rcore-fs-sefs/src/lib.rs
@@ -395,18 +395,9 @@ impl vfs::INode for INodeImpl {
             mode: disk_inode.mode,
             type_: vfs::FileType::from(disk_inode.type_),
             blocks: disk_inode.blocks as usize,
-            atime: Timespec {
-                sec: disk_inode.atime as i64,
-                nsec: 0,
-            },
-            mtime: Timespec {
-                sec: disk_inode.mtime as i64,
-                nsec: 0,
-            },
-            ctime: Timespec {
-                sec: disk_inode.ctime as i64,
-                nsec: 0,
-            },
+            atime: disk_inode.atime,
+            mtime: disk_inode.mtime,
+            ctime: disk_inode.ctime,
             nlinks: disk_inode.nlinks as usize,
             uid: disk_inode.uid as usize,
             gid: disk_inode.gid as usize,
@@ -420,9 +411,9 @@ impl vfs::INode for INodeImpl {
         disk_inode.mode = metadata.mode;
         disk_inode.uid = metadata.uid as u32;
         disk_inode.gid = metadata.gid as u32;
-        disk_inode.atime = metadata.atime.sec as u32;
-        disk_inode.mtime = metadata.mtime.sec as u32;
-        disk_inode.ctime = metadata.ctime.sec as u32;
+        disk_inode.atime = metadata.atime;
+        disk_inode.mtime = metadata.mtime;
+        disk_inode.ctime = metadata.ctime;
         Ok(())
     }
 
@@ -1077,10 +1068,10 @@ impl SEFS {
     fn new_inode(&self, type_: FileType, mode: u16) -> vfs::Result<Arc<INodeImpl>> {
         let id = self.alloc_block().ok_or(FsError::NoDeviceSpace)?;
         let (time, uuid) = if cfg!(feature = "create_image") && self.device.protect_integrity() {
-            (0, SefsUuid::from(id))
+            (Default::default(), SefsUuid::from(id))
         } else {
             (
-                self.time_provider.current_time().sec as u32,
+                self.time_provider.current_time(),
                 self.uuid_provider.generate_uuid(),
             )
         };

--- a/rcore-fs-sefs/src/structs.rs
+++ b/rcore-fs-sefs/src/structs.rs
@@ -1,12 +1,11 @@
 //! On-disk structures in SEFS
-
+use super::dev::{SefsMac, SefsUuid};
 use alloc::str;
 use core::fmt::{Debug, Error, Formatter};
 use core::mem::{size_of, size_of_val};
 use core::slice;
+use rcore_fs::vfs::Timespec;
 use static_assertions::const_assert;
-
-use super::dev::{SefsMac, SefsUuid};
 
 /// On-disk superblock, 32-bit aligned
 #[repr(C)]
@@ -39,9 +38,9 @@ pub struct DiskINode {
     pub blocks: u32,
     pub uid: u32,
     pub gid: u32,
-    pub atime: u32,
-    pub mtime: u32,
-    pub ctime: u32,
+    pub atime: Timespec,
+    pub mtime: Timespec,
+    pub ctime: Timespec,
     pub disk_filename: SefsUuid,
     pub inode_mac: SefsMac,
 }

--- a/rcore-fs/src/dev/std_impl.rs
+++ b/rcore-fs/src/dev/std_impl.rs
@@ -38,7 +38,7 @@ impl TimeProvider for StdTimeProvider {
         let duration = SystemTime::now().duration_since(UNIX_EPOCH).unwrap();
         Timespec {
             sec: duration.as_secs() as i64,
-            nsec: duration.subsec_nanos() as i32,
+            nsec: duration.subsec_nanos() as i64,
         }
     }
 }

--- a/rcore-fs/src/std.rs
+++ b/rcore-fs/src/std.rs
@@ -28,15 +28,15 @@ impl From<std::fs::Metadata> for Metadata {
             blocks: m.blocks() as usize,
             atime: Timespec {
                 sec: m.atime(),
-                nsec: m.atime_nsec() as i32,
+                nsec: m.atime_nsec(),
             },
             mtime: Timespec {
                 sec: m.mtime(),
-                nsec: m.mtime_nsec() as i32,
+                nsec: m.mtime_nsec(),
             },
             ctime: Timespec {
                 sec: m.ctime(),
-                nsec: m.ctime_nsec() as i32,
+                nsec: m.ctime_nsec(),
             },
             type_: match (m.mode() & 0xf000) as _ {
                 libc::S_IFCHR => FileType::CharDevice,

--- a/rcore-fs/src/vfs.rs
+++ b/rcore-fs/src/vfs.rs
@@ -291,10 +291,11 @@ pub struct Metadata {
     pub rdev: usize, // (major << 8) | minor
 }
 
-#[derive(Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Debug, Hash)]
+#[repr(C)]
+#[derive(Default, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Debug, Hash)]
 pub struct Timespec {
     pub sec: i64,
-    pub nsec: i32,
+    pub nsec: i64,
 }
 
 #[derive(Copy, Clone, Debug, Eq, PartialEq)]


### PR DESCRIPTION
Cannot get correct time when running java/c program in occlum due to incompatible timespec convertion from Rust to C. Actually, the ability of getting correct time is very important for some applications, for example, using JAVA FileLock which repetitively check file last-change time. This bug would make those application rush to error.
The bug is caused by incompatible timespec conversion in Rust ({i64, i32}) and C ({long, long}). When C program invokes a Rust lib to get one variable (e.g., info) including  timespec-type value (e.g., info.cur), the result in C  is not same to that generated in Rust.
In additional, thanks to @liqinggd for his generous help.
One sample code: C program invokes Rust lib. Results in C and those in Rust are not same.
The part in C:
```
struct InfoStruct {
    long a;
    long b;
    long c;
    long d;
    struct timespec cur;
};
extern void foo(struct InfoStruct* info);

int main(){
    struct InfoStruct info;
    foo(&info);
    printf("C: info.a: %ld, info.b: %ld, info.c: %ld, info.d: %ld  \n", info.a, info.b, info.c, info.d);
    printf("C: info.cur.tv_sec: %ld, info.cur.tv_nsec: %ld \n", info.cur.tv_sec, info.cur.tv_nsec);
}
```

The part in Rust:
```
#[repr(C)]
pub struct InfoStruct {
    a: i64,
    b: i64,
    c: i64,
    d: i64,
    cur: time::Timespec,
}

fn get_info() -> InfoStruct {
    InfoStruct {
        a: 123456789,
        b: 123456789,
        c: 345678912,
        d: 456789123,
        cur: time::get_time(),
   }
}

pub extern "C" fn foo(info: *mut InfoStruct) {    
    let info_test = get_info();
    unsafe {
        info.write(info_test);
        println!("rust: info : a: {}, b: {}, c: {}, d: {}", (*info).a, (*info).b, (*info).c, (*info).d);
        println!("rust: info cur = {:?}", (*info).cur);
    }
}
```