### PR TITLE
fix the deterministic MAC issue of integrity-only sefs

### DIFF
--- a/rcore-fs-sefs/src/lib.rs
+++ b/rcore-fs-sefs/src/lib.rs
@@ -19,7 +19,7 @@ use bitvec::prelude::*;
 use rcore_fs::dev::{DevResult, TimeProvider};
 use rcore_fs::dirty::Dirty;
 use rcore_fs::vfs::{
-    self, AllocFlags, DirentWriterContext, FallocateMode, FileSystem, FsError, INode, Timespec,
+    self, AllocFlags, DirentWriterContext, FallocateMode, FileSystem, FsError, INode,
 };
 use spin::{RwLock, RwLockWriteGuard};
 
@@ -1100,6 +1100,7 @@ impl SEFS {
             blocks: 0,
             uid: 0,
             gid: 0,
+            pad: 0,
             atime: time,
             mtime: time,
             ctime: time,

--- a/rcore-fs-sefs/src/structs.rs
+++ b/rcore-fs-sefs/src/structs.rs
@@ -21,7 +21,7 @@ pub struct SuperBlock {
     pub groups: u32,
 }
 
-/// On-disk inode, 32-bit aligned
+/// On-disk inode, 64-bit aligned
 #[repr(C)]
 #[derive(Debug)]
 pub struct DiskINode {
@@ -38,6 +38,7 @@ pub struct DiskINode {
     pub blocks: u32,
     pub uid: u32,
     pub gid: u32,
+    pub pad: u32,
     pub atime: Timespec,
     pub mtime: Timespec,
     pub ctime: Timespec,

--- a/sefs-cli/app/src/main.rs
+++ b/sefs-cli/app/src/main.rs
@@ -159,6 +159,7 @@ fn main() -> Result<(), Box<dyn Error>> {
                 sefs::SEFS::create(Box::new(device), &StdTimeProvider, &StdUuidProvider)?
             };
             zip_dir(&dir, sefs_fs.root_inode())?;
+            sefs_fs.sync()?;
             let root_mac_str = {
                 let mut s = String::from("");
                 for (i, byte) in sefs_fs.root_mac().iter().enumerate() {


### PR DESCRIPTION
If `DiskINode` is not 64-bit aligned, the padding bytes are randomly generated on some machine, which makes the MAC of interigity sefs is not deterministic